### PR TITLE
ci: Add GitHub Action workflow to validate PR title

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,21 @@
+name: Lint PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
PR titles must follow the conventional commit spec: https://www.conventionalcommits.org/en/v1.0.0/

Expect the status check for this PR to fail until this has been merged to main. This happens because the `pull_request_target` trigger is being used instead of `pull_request`, which is needed for public repos that accept PRs from forked repos. See https://github.com/amannn/action-semantic-pull-request?tab=readme-ov-file#event-triggers for more details.