### PR TITLE
feat: build Docker image containing seed data

### DIFF
--- a/.github/workflows/build-seed-data.yaml
+++ b/.github/workflows/build-seed-data.yaml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+    paths:
+      - .github/workflows/build-seed-data.yaml
+      - "resources/Dockerfile"
+      - "resources/seed/**"
+
+env:
+  docker_image_tag: ${{ github.ref == 'refs/heads/main' && github.sha || github.ref_name }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: integration-os/google-artifact-registry-action@v2
+        with:
+          image: "us-docker.pkg.dev/integrationos/docker-oss/seed-data:${{ env.docker_image_tag }}"
+          service_account: github-actions@integrationos.iam.gserviceaccount.com
+          workload_identity_provider: projects/356173785332/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+          context: resources
+          file: resources/Dockerfile

--- a/README.md
+++ b/README.md
@@ -148,12 +148,13 @@ View the full guide [here](https://docs.integrationos.com/docs/quickstart).
     ```shell
     docker-compose up -d
     ```
-3. Run migrations
+3. Run migrations and load seed data
 
     ```shell
     source .env
     docker-compose -f docker-compose.data.yml run --rm migrate-before
     docker-compose -f docker-compose.data.yml run --rm migrate-after
+    docker-compose -f docker-compose.data.yml run --rm seed-data
     ```
 
 **Note:** If you want to run the latest version of the docker image, you can use the latest git commit hash as the tag. For example, `integrationos/integrationos:<commit-hash>`.

--- a/docker-compose.data.yml
+++ b/docker-compose.data.yml
@@ -16,3 +16,13 @@ services:
     environment:
       - MONGO_URI=mongodb://integrationos:${MONGO_PASSWORD}@mongo:27017/events-service?authSource=admin
       - MONGO_DB_NAME=events-service
+
+  seed-data:
+    platform: linux/amd64
+    image: us-docker.pkg.dev/integrationos/docker-oss/seed-data:1.11.0
+    restart: "no"
+    environment:
+      - MONGO_HOST=mongo
+      - MONGO_DATABASE=events-service
+      - MONGO_USERNAME=integrationos
+      - MONGO_PASSWORD=${MONGO_PASSWORD}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,14 +140,5 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD}
       - MONGO_INITDB_ROOT_USERNAME=integrationos
 
-  setup:
-    image: mongo:6.0
-    depends_on:
-      - mongo
-    restart: "no"
-    volumes:
-      - ./resources:/resources:ro
-    entrypoint: ["/bin/bash", "-c", "sleep 10 && mongorestore --host mongo --nsFrom='seed.*' --nsTo='events-service.*' --authenticationDatabase admin -u integrationos -p ${MONGO_PASSWORD} /resources"]
-
   redis:
     image: redis:7.0

--- a/resources/Dockerfile
+++ b/resources/Dockerfile
@@ -1,0 +1,6 @@
+FROM mongo:6.0
+
+COPY seed /app/integrationos/resources/seed
+WORKDIR /app/integrationos/
+
+ENTRYPOINT ["/bin/bash", "-c", "set -u && mongorestore --host ${MONGO_HOST} --nsFrom=seed.* --nsTo=${MONGO_DATABASE}.* --authenticationDatabase admin -u ${MONGO_USERNAME} -p ${MONGO_PASSWORD} ./resources"]


### PR DESCRIPTION
Also move the seed-data service out of the main `docker-compose.yml` file and into `docker-compose.data.yml` so that it doesn't get run every time a developer runs `docker-compose up`, similar to how the migration scripts work.

The `us-docker.pkg.dev/integrationos/docker-oss/seed-data:1.11.0` image doesn't exist yet. It will get created when the next release tag is created later today.