### PR TITLE
feat: pass environment on connection create

### DIFF
--- a/integrationos-api/src/endpoints/common_model.rs
+++ b/integrationos-api/src/endpoints/common_model.rs
@@ -86,7 +86,7 @@ impl RequestExt for CreateRequest {
 
     fn from(&self) -> Option<Self::Output> {
         let mut record = Self::Output {
-            id: Id::now(IdPrefix::CommonModel),
+            id: self._id.unwrap_or_else(|| Id::now(IdPrefix::CommonModel)),
             name: self.name.clone(),
             fields: self.fields.clone(),
             sample: self.sample.clone(),

--- a/integrationos-api/src/endpoints/connection_definition.rs
+++ b/integrationos-api/src/endpoints/connection_definition.rs
@@ -288,7 +288,9 @@ impl RequestExt for CreateRequest {
         let key = format!("api::{}::{}", self.platform, self.platform_version);
 
         let mut record = Self::Output {
-            id: Id::now(IdPrefix::ConnectionDefinition),
+            id: self
+                ._id
+                .unwrap_or_else(|| Id::now(IdPrefix::ConnectionDefinition)),
             platform_version: self.platform_version.clone(),
             platform: self.platform.clone(),
             status: self.status.clone(),

--- a/integrationos-api/src/endpoints/connection_model_definition.rs
+++ b/integrationos-api/src/endpoints/connection_model_definition.rs
@@ -319,7 +319,9 @@ impl RequestExt for CreateRequest {
         .to_lowercase();
 
         let mut record = Self::Output {
-            id: Id::new(IdPrefix::ConnectionModelDefinition, Utc::now()),
+            id: self
+                ._id
+                .unwrap_or_else(|| Id::now(IdPrefix::ConnectionModelDefinition)),
             connection_platform: self.connection_platform.clone(),
             connection_definition_id: self.connection_definition_id,
             platform_version: self.platform_version.clone(),

--- a/integrationos-api/src/endpoints/connection_model_schema.rs
+++ b/integrationos-api/src/endpoints/connection_model_schema.rs
@@ -180,7 +180,9 @@ impl RequestExt for CreateRequest {
         .to_lowercase();
 
         Some(Self::Output {
-            id: Id::now(IdPrefix::ConnectionModelSchema),
+            id: self
+                ._id
+                .unwrap_or_else(|| Id::now(IdPrefix::ConnectionModelSchema)),
             platform_id: self.platform_id,
             platform_page_id: self.platform_page_id,
             connection_platform: self.connection_platform.clone(),

--- a/integrationos-api/src/endpoints/connection_oauth_definition.rs
+++ b/integrationos-api/src/endpoints/connection_oauth_definition.rs
@@ -70,7 +70,9 @@ impl RequestExt for CreateRequest {
 
     fn from(&self) -> Option<Self::Output> {
         Some(Self::Output {
-            id: Id::new(IdPrefix::ConnectionOAuthDefinition, Utc::now()),
+            id: self
+                ._id
+                .unwrap_or_else(|| Id::now(IdPrefix::ConnectionOAuthDefinition)),
             connection_platform: self.connection_platform.clone(),
             configuration: OAuthApiConfig {
                 init: self.init.configuration.clone(),

--- a/integrationos-api/src/endpoints/oauth.rs
+++ b/integrationos-api/src/endpoints/oauth.rs
@@ -114,11 +114,18 @@ async fn oauth_handler(
         e
     })?;
 
-    let oauth_payload = OAuthPayload {
+    let mut oauth_payload = OAuthPayload {
         metadata: payload.payload.clone().unwrap_or(Value::Null),
         client_id: payload.client_id,
         client_secret: secret.client_secret,
     };
+
+    if let Some(metadata) = oauth_payload.metadata.as_object_mut() {
+        metadata.insert(
+            "environment".to_string(),
+            Value::String(environment.to_string()),
+        );
+    }
 
     let conn_oauth_definition = if conn_oauth_definition.is_full_template_enabled {
         state

--- a/integrationos-api/src/endpoints/platform.rs
+++ b/integrationos-api/src/endpoints/platform.rs
@@ -31,6 +31,7 @@ pub fn get_router() -> Router<Arc<AppState>> {
 #[cfg_attr(feature = "dummy", derive(fake::Dummy))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRequest {
+    pub _id: Option<Id>,
     pub connection_definition_id: Id,
     pub name: String,
     pub url: String,
@@ -47,7 +48,7 @@ impl RequestExt for CreateRequest {
 
     fn from(&self) -> Option<Self::Output> {
         Some(Self::Output {
-            id: Id::now(IdPrefix::Platform),
+            id: self._id.unwrap_or_else(|| Id::now(IdPrefix::Platform)),
             connection_definition_id: self.connection_definition_id,
             name: self.name.clone(),
             url: self.url.clone(),

--- a/integrationos-api/src/endpoints/platform_page.rs
+++ b/integrationos-api/src/endpoints/platform_page.rs
@@ -41,6 +41,7 @@ pub fn get_router() -> Router<Arc<AppState>> {
 #[cfg_attr(feature = "dummy", derive(fake::Dummy))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRequest {
+    pub _id: Option<Id>,
     pub platform_id: Id,
     pub connection_definition_id: Id,
     pub platform_name: String,
@@ -103,7 +104,7 @@ impl RequestExt for CreateRequest {
         let hashed = HashedSecret::try_from(hash_value).ok()?;
 
         Some(Self::Output {
-            id: Id::now(IdPrefix::PlatformPage),
+            id: self._id.unwrap_or_else(|| Id::now(IdPrefix::PlatformPage)),
             platform_id: self.platform_id,
             platform_name: self.platform_name.clone(),
             connection_definition_id: self.connection_definition_id,

--- a/integrationos-platform-oauth/src/connections/clover/init.ts
+++ b/integrationos-platform-oauth/src/connections/clover/init.ts
@@ -11,7 +11,9 @@ export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
             client_secret: body.clientSecret,
         };
 
-        const response = await axios.post(`${body.metadata.formData.CLOVER_REGION_DOMAIN}/oauth/token`, requestBody);
+        const baseUrl = body.metadata?.environment === "live" ? "https://api.clover.com" : "https://sandbox.dev.clover.com";
+
+        const response = await axios.post(`${baseUrl}/oauth/token`, requestBody);
 
         const accessToken = response.data?.access_token;
 
@@ -23,6 +25,7 @@ export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
             meta: {
                 merchantId: body.metadata?.additionalData?.merchant_id,
                 employeeId: body.metadata?.additionalData?.employee_id,
+                baseUrl
             }
         };
     } catch (error) {

--- a/integrationos-platform-oauth/src/connections/quickbooks/init.ts
+++ b/integrationos-platform-oauth/src/connections/quickbooks/init.ts
@@ -30,6 +30,8 @@ export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
       },
     } = response;
 
+    const baseUrl = body.metadata?.environment === "live" ? "https://quickbooks.api.intuit.com" : "https://sandbox-quickbooks.api.intuit.com";
+
     return {
       accessToken,
       refreshToken,
@@ -37,6 +39,7 @@ export const init = async ({ body }: DataObject): Promise<OAuthResponse> => {
       tokenType,
       meta: {
         realmId: body.metadata?.additionalData?.realmId,
+        baseUrl
       },
     };
   } catch (error) {


### PR DESCRIPTION
- Pass environment in metadata to oauth connections
- Set Clover API base url based on environment
- Set Quickbooks API base url based on environment