### PR TITLE
fix: sign connection model definition query parameters in oauth 1.0 request

### DIFF
--- a/integrationos-domain/src/service/client/caller_client.rs
+++ b/integrationos-domain/src/service/client/caller_client.rs
@@ -110,8 +110,11 @@ impl<'a> CallerClient<'a> {
                 })?;
 
                 let mut signable_request_params = IndexMap::new();
-                if let Some(query_params) = query_params {
-                    signable_request_params.extend(query_params.clone());
+                if let Some(custom_query_params) = query_params {
+                    signable_request_params.extend(custom_query_params.clone());
+                }
+                if let Some(model_query_params) = &self.config.query_params {
+                    signable_request_params.extend(model_query_params.clone());
                 }
 
                 let signable_request = SignableRequest {


### PR DESCRIPTION
Signs connection model definition query parameters in addition to the custom query parameters when making oauth 1.0 requests.